### PR TITLE
Make /bin/wp executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y sudo less
 # Add WP-CLI 
 RUN curl -o /bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 COPY wp-su.sh /bin/wp
-RUN chmod +x /bin/wp-cli.phar
+RUN chmod +x /bin/wp-cli.phar /bin/wp
 
 # Cleanup
 RUN apt-get clean


### PR DESCRIPTION
This makes the /bin/wp script executable as well. wp-su.sh is executable,
but in the instance that it someone loses it's mode, this ensures that it will
always be executable in the container.
